### PR TITLE
Add interactive Vega diagram features

### DIFF
--- a/fishbone-app/package-lock.json
+++ b/fishbone-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-zoom-pan-pinch": "^3.7.0",
         "vega": "^6.1.2",
         "vega-embed": "^7.0.2",
         "vega-lite": "^6.1.0"
@@ -2902,6 +2903,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/require-directory": {

--- a/fishbone-app/package.json
+++ b/fishbone-app/package.json
@@ -14,7 +14,8 @@
     "react-dom": "^19.1.0",
     "vega": "^6.1.2",
     "vega-embed": "^7.0.2",
-    "vega-lite": "^6.1.0"
+    "vega-lite": "^6.1.0",
+    "react-zoom-pan-pinch": "^3.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/fishbone-app/src/App.css
+++ b/fishbone-app/src/App.css
@@ -4,3 +4,16 @@
   padding: 2rem;
   font-family: sans-serif;
 }
+
+.diagram-container {
+  position: relative;
+}
+
+.info-box {
+  position: absolute;
+  background: white;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  z-index: 10;
+}

--- a/fishbone-app/src/App.jsx
+++ b/fishbone-app/src/App.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import vegaEmbed from 'vega-embed'
+import { TransformWrapper, TransformComponent, MiniMap } from 'react-zoom-pan-pinch'
 import data from './data/example.json'
 import './App.css'
 
-function generateSpec(d) {
+function generateSpec(d, collapsed = {}) {
   const width = 800
   const height = 400
   const midY = height / 2
@@ -14,7 +15,7 @@ function generateSpec(d) {
 
   // main spine
   lines.push({ x1: 50, y1: midY, x2: width - 100, y2: midY, category: 'main' })
-  labels.push({ x: width - 90, y: midY - 10, text: d.fehler, category: 'main', align: 'left' })
+  labels.push({ x: width - 90, y: midY - 10, text: d.fehler, category: 'main', align: 'left', type: 'root', link: d.link, raw: d })
 
   d.kategorien.forEach((cat, i) => {
     const baseX = 50 + (i + 1) * catSpacing
@@ -24,15 +25,17 @@ function generateSpec(d) {
     const x2 = baseX
     const y2 = midY + orientation * 60
     lines.push({ x1, y1, x2, y2, category: cat.name })
-    labels.push({ x: x2 + 5, y: y2, text: cat.name, category: cat.name, align: 'left' })
-    cat.ursachen.forEach((cause, j) => {
-      const cx2 = x2
-      const cy2 = y2 + orientation * (j + 1) * 20
-      const cx1 = cx2 - 30
-      const cy1 = cy2
-      lines.push({ x1: cx1, y1: cy1, x2: cx2, y2: cy2, category: cat.name })
-      labels.push({ x: cx1 - 5, y: cy1, text: cause.name, category: cat.name, align: 'right' })
-    })
+    labels.push({ x: x2 + 5, y: y2, text: cat.name, category: cat.name, align: 'left', type: 'category', link: cat.link, raw: cat })
+    if (!collapsed[cat.name]) {
+      cat.ursachen.forEach((cause, j) => {
+        const cx2 = x2
+        const cy2 = y2 + orientation * (j + 1) * 20
+        const cx1 = cx2 - 30
+        const cy1 = cy2
+        lines.push({ x1: cx1, y1: cy1, x2: cx2, y2: cy2, category: cat.name })
+        labels.push({ x: cx1 - 5, y: cy1, text: cause.name, category: cat.name, align: 'right', type: 'cause', link: cause.link, raw: cause })
+      })
+    }
   })
 
   return {
@@ -84,7 +87,8 @@ function generateSpec(d) {
               { scale: 'color', field: 'category' }
             ],
             fontSize: { value: 12 },
-            text: { field: 'text' }
+            text: { field: 'text' },
+            href: { field: 'link' }
           }
         }
       }
@@ -94,16 +98,60 @@ function generateSpec(d) {
 
 function App() {
   const ref = useRef(null)
+  const viewRef = useRef(null)
+  const [collapsed, setCollapsed] = useState({})
+  const [info, setInfo] = useState(null)
 
   useEffect(() => {
-    const spec = generateSpec(data)
-    vegaEmbed(ref.current, spec, { actions: false })
-  }, [])
+    const spec = generateSpec(data, collapsed)
+    if (ref.current) ref.current.innerHTML = ''
+    let view
+    let handler
+    vegaEmbed(ref.current, spec, { actions: false }).then(res => {
+      view = res.view
+      viewRef.current = view
+      handler = (event, item) => {
+        if (item && item.datum) {
+          if (item.datum.type === 'category') {
+            setCollapsed(c => ({ ...c, [item.datum.text]: !c[item.datum.text] }))
+          }
+          setInfo({ datum: item.datum, x: event.clientX, y: event.clientY })
+        }
+      }
+      view.addEventListener('click', handler)
+    })
+    return () => {
+      if (view) {
+        view.removeEventListener('click', handler)
+      }
+    }
+  }, [collapsed])
 
   return (
-    <div>
+    <div className="diagram-container">
       <h1>Fishbone Diagram</h1>
-      <div ref={ref}></div>
+      <TransformWrapper>
+        <MiniMap />
+        <TransformComponent>
+          <div ref={ref}></div>
+        </TransformComponent>
+      </TransformWrapper>
+      {info && (
+        <div className="info-box" style={{ left: info.x, top: info.y }}>
+          <strong>{info.datum.text}</strong>
+          {info.datum.raw?.status && <div>Status: {info.datum.raw.status}</div>}
+          {info.datum.raw?.punkte && <div>Punkte: {info.datum.raw.punkte}</div>}
+          {info.datum.raw?.prioritaet && <div>Priorität: {info.datum.raw.prioritaet}</div>}
+          {info.datum.link && (
+            <div>
+              <a href={info.datum.link} target="_blank" rel="noreferrer">
+                Link
+              </a>
+            </div>
+          )}
+          <button onClick={() => setInfo(null)}>Schließen</button>
+        </div>
+      )}
     </div>
   )
 }

--- a/fishbone-app/src/data/example.json
+++ b/fishbone-app/src/data/example.json
@@ -1,44 +1,51 @@
 {
   "fehler": "Produktausfall",
+  "link": "https://beispiel.de/Produktausfall",
   "kategorien": [
     {
       "name": "Mensch",
+      "link": "https://beispiel.de/Mensch",
       "ursachen": [
-        {"name": "Fehlbedienung", "status": "offen", "punkte": 3, "prioritaet": "hoch"},
-        {"name": "Unzureichende Schulung", "status": "offen", "punkte": 2, "prioritaet": "mittel"}
+        {"name": "Fehlbedienung", "status": "offen", "punkte": 3, "prioritaet": "hoch", "link": "https://beispiel.de/Fehlbedienung"},
+        {"name": "Unzureichende Schulung", "status": "offen", "punkte": 2, "prioritaet": "mittel", "link": "https://beispiel.de/UnzureichendeSchulung"}
       ]
     },
     {
       "name": "Maschine",
+      "link": "https://beispiel.de/Maschine",
       "ursachen": [
-        {"name": "Defekte Teile", "status": "offen", "punkte": 4, "prioritaet": "hoch"},
-        {"name": "Mangelnde Wartung", "status": "offen", "punkte": 2, "prioritaet": "mittel"}
+        {"name": "Defekte Teile", "status": "offen", "punkte": 4, "prioritaet": "hoch", "link": "https://beispiel.de/DefekteTeile"},
+        {"name": "Mangelnde Wartung", "status": "offen", "punkte": 2, "prioritaet": "mittel", "link": "https://beispiel.de/MangelndeWartung"}
       ]
     },
     {
       "name": "Methode",
+      "link": "https://beispiel.de/Methode",
       "ursachen": [
-        {"name": "Falsches Verfahren", "status": "offen", "punkte": 3, "prioritaet": "mittel"},
-        {"name": "Fehlende Standards", "status": "offen", "punkte": 2, "prioritaet": "niedrig"}
+        {"name": "Falsches Verfahren", "status": "offen", "punkte": 3, "prioritaet": "mittel", "link": "https://beispiel.de/FalschesVerfahren"},
+        {"name": "Fehlende Standards", "status": "offen", "punkte": 2, "prioritaet": "niedrig", "link": "https://beispiel.de/FehlendeStandards"}
       ]
     },
     {
       "name": "Material",
+      "link": "https://beispiel.de/Material",
       "ursachen": [
-        {"name": "Schlechtes Material", "status": "offen", "punkte": 5, "prioritaet": "hoch"},
-        {"name": "Falscher Lieferant", "status": "offen", "punkte": 2, "prioritaet": "mittel"}
+        {"name": "Schlechtes Material", "status": "offen", "punkte": 5, "prioritaet": "hoch", "link": "https://beispiel.de/SchlechtesMaterial"},
+        {"name": "Falscher Lieferant", "status": "offen", "punkte": 2, "prioritaet": "mittel", "link": "https://beispiel.de/FalscherLieferant"}
       ]
     },
     {
       "name": "Mitwelt",
+      "link": "https://beispiel.de/Mitwelt",
       "ursachen": [
-        {"name": "Umgebungstemperatur", "status": "offen", "punkte": 2, "prioritaet": "mittel"}
+        {"name": "Umgebungstemperatur", "status": "offen", "punkte": 2, "prioritaet": "mittel", "link": "https://beispiel.de/Umgebungstemperatur"}
       ]
     },
     {
       "name": "Messung",
+      "link": "https://beispiel.de/Messung",
       "ursachen": [
-        {"name": "Fehlerhafte Sensoren", "status": "offen", "punkte": 3, "prioritaet": "hoch"}
+        {"name": "Fehlerhafte Sensoren", "status": "offen", "punkte": 3, "prioritaet": "hoch", "link": "https://beispiel.de/FehlerhafteSensoren"}
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- support link fields in diagram data
- add zoom, minimap and info box to Vega diagram
- allow collapsing categories on click
- style diagram container and info box
- add `react-zoom-pan-pinch` dependency

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854056ffd5c832f84dfa441e50931b0