### PR TITLE
Improve viewport usage and hover info

### DIFF
--- a/fishbone-app/src/App.css
+++ b/fishbone-app/src/App.css
@@ -1,12 +1,16 @@
 #root {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 2rem;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
   font-family: sans-serif;
+  overflow: hidden;
 }
 
 .diagram-container {
   position: relative;
+  width: 100%;
+  height: 100%;
 }
 
 .info-box {
@@ -16,4 +20,10 @@
   padding: 0.5rem;
   font-size: 0.9rem;
   z-index: 10;
+}
+
+.rzpp-mini-map {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
 }

--- a/fishbone-app/src/index.css
+++ b/fishbone-app/src/index.css
@@ -24,10 +24,10 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
+  width: 100vw;
+  height: 100vh;
   min-width: 320px;
-  min-height: 100vh;
+  overflow: hidden;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- make app fill entire viewport
- resize Vega spec on window resize
- show info on hover instead of click
- position minimap bottom-right

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854088bcfe4832f866ad308f0216263