### PR TITLE
Fix drawer and info box

### DIFF
--- a/fishbone-app/src/App.jsx
+++ b/fishbone-app/src/App.jsx
@@ -34,7 +34,7 @@ function generateSpec(d, collapsed = {}, width, height) {
     const x1 = baseX - 50
     const y1 = midY
     const x2 = baseX
-    const y2 = midY + orientation * 60
+    const y2 = midY + orientation * 80
     lines.push({ x1, y1, x2, y2, category: cat.name })
     labels.push({ x: x2 + 5, y: y2, text: cat.name, category: cat.name, align: 'left', type: 'category', link: cat.link, raw: cat })
     if (!collapsed[cat.name]) {
@@ -227,11 +227,9 @@ function App() {
         </Toolbar>
       </AppBar>
       <Drawer
-        variant="temporary"
+        variant="persistent"
         anchor="left"
         open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        ModalProps={{ keepMounted: true }}
         sx={{
           flexShrink: 0,
           [`& .MuiDrawer-paper`]: {
@@ -295,7 +293,6 @@ function App() {
                 </a>
               </div>
             )}
-            <button onClick={() => setInfo(null)}>Schließen</button>
           </div>
         )}
       </Box>


### PR DESCRIPTION
## Summary
- keep page active when sidebar opens
- remove close button from info popup
- make category branches longer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68550000d464832fa9e960f3de255edb